### PR TITLE
Fix Meadow incompatibilities with Fable 2.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ build/Release
 # Commenting this out is preferred by some people, see
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git-
 node_modules
+package-lock.json
 
 # Users Environment Variables
 .lock-wscript

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: node_js
 node_js:
   - "6"
   - "8"
+services:
+  - mysql
 before_script:
   - mysql -e 'CREATE DATABASE FableTest;'
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: node_js
 node_js:
   - "6"
   - "8"
+  - "12"
+  - "15"
 services:
   - mysql
 before_script:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meadow",
-  "version": "1.0.28",
+  "version": "1.0.30",
   "description": "A data access library.",
   "main": "source/Meadow.js",
   "scripts": {
@@ -26,19 +26,19 @@
   },
   "homepage": "https://github.com/stevenvelozo/meadow",
   "devDependencies": {
+    "alasql": "^0.4.0",
     "chai": "3.5.0",
     "codeclimate-test-reporter": "0.4.1",
-    "alasql": "^0.4.0",
-    "mysql2": "1.2.0",
     "coveralls": "2.13.1",
     "groc": "^0.8.0",
     "istanbul": "0.4.5",
-    "mocha": "3.4.1"
+    "mocha": "3.4.1",
+    "mysql2": "1.2.0"
   },
   "dependencies": {
     "async": "2.4.0",
     "fable": "~1.0.1",
-    "foxhound": "~1.0.22",
+    "foxhound": "~1.0.31",
     "is-my-json-valid": "2.16.0",
     "underscore": "1.8.3"
   }

--- a/source/Meadow-RawQuery.js
+++ b/source/Meadow-RawQuery.js
@@ -24,7 +24,7 @@ var MeadowRawQuery = function()
 	function createNew(pMeadow)
 	{
 		// If a valid Fable object isn't passed in, return a constructor
-		if ((typeof(pMeadow) !== 'object') || (!pMeadow.hasOwnProperty('fable')))
+		if ((typeof(pMeadow) !== 'object') || !('fable' in pMeadow))
 		{
 			return {new: createNew};
 		}

--- a/source/Meadow.js
+++ b/source/Meadow.js
@@ -279,14 +279,23 @@ var Meadow = function()
 		/**
 		 * Get the role name for an index
 		 */
-		var _RoleNames = [
-			"Unauthenticated",
-			"User",
-			"Manager",
-			"Director",
-			"Executive",
-			"Administrator"
-		];
+		let _RoleNames;
+		if (Array.isArray(_Fable.settings.MeadowRoleNames))
+		{
+			_RoleNames = _Fable.settings.MeadowRoleNames;
+		}
+		else
+		{
+			_RoleNames =
+			[
+				'Unauthenticated',
+				'User',
+				'Manager',
+				'Director',
+				'Executive',
+				'Administrator',
+			];
+		}
 		var getRoleName = function(pRoleIndex)
 		{
 			if (pRoleIndex < 0 || pRoleIndex >= _RoleNames.length)

--- a/source/Meadow.js
+++ b/source/Meadow.js
@@ -16,7 +16,7 @@ var Meadow = function()
 	function createNew(pFable, pScope, pJsonSchema, pSchema)
 	{
 		// If a valid Fable object isn't passed in, return a constructor
-		if ((typeof(pFable) !== 'object') || (!pFable.hasOwnProperty('fable')))
+		if ((typeof(pFable) !== 'object') || !('fable' in pFable))
 		{
 			return {new: createNew};
 		}
@@ -110,8 +110,8 @@ var Meadow = function()
 			_IDUser = pIDUser;
 			return this;
 		};
-		
-		
+
+
 		/**
 		* Set the Provider for Query execution.
 		*
@@ -126,7 +126,7 @@ var Meadow = function()
 		{
 			if (typeof(pProviderName) !== 'string')
 			{
-				return setProvider('None');
+				pProviderName = 'None';
 			}
 
 			var tmpProviderModuleFile = './providers/Meadow-Provider-'+pProviderName+'.js';
@@ -139,12 +139,11 @@ var Meadow = function()
 				// Give the provider access to the schema object
 				updateProviderState();
 
-				
 				_ProviderName = pProviderName;
 			}
 			catch (pError)
 			{
-				_Fable.log.error({ProviderModuleFile:tmpProviderModuleFile, InvalidProvider:pProviderName, error:pError}, 'Provider not set - require load problem');
+				_Fable.log.error('Provider not set - require load problem', {ProviderModuleFile:tmpProviderModuleFile, InvalidProvider:pProviderName, error:pError});
 				//setProvider('None');
 			}
 
@@ -520,7 +519,32 @@ var Meadow = function()
 				enumerable: true
 			});
 
-		_Fable.addServices(tmpNewMeadowObject);
+		// addServices removed in fable 2.x
+		if (typeof(_Fable.addServices) === 'function')
+		{
+			_Fable.addServices(tmpNewMeadowObject);
+		}
+		else
+		{
+			// bring over addServices implementation from Fable 1.x for backward compatibility
+			Object.defineProperty(tmpNewMeadowObject, 'fable',
+			{
+				get: function() { return _Fable; },
+				enumerable: false,
+			});
+
+			Object.defineProperty(tmpNewMeadowObject, 'settings',
+			{
+				get: function() { return _Fable.settings; },
+				enumerable: false,
+			});
+
+			Object.defineProperty(tmpNewMeadowObject, 'log',
+			{
+				get: function() { return _Fable.log; },
+				enumerable: false,
+			});
+		}
 
 		return tmpNewMeadowObject;
 	}

--- a/source/providers/Meadow-Provider-None.js
+++ b/source/providers/Meadow-Provider-None.js
@@ -9,7 +9,7 @@ var MeadowProvider = function()
 	function createNew(pFable)
 	{
 		// If a valid Fable object isn't passed in, return a constructor
-		if ((typeof(pFable) !== 'object') || (!pFable.hasOwnProperty('fable')))
+		if ((typeof(pFable) !== 'object') || !('fable' in pFable))
 		{
 			return {new: createNew};
 		}

--- a/test/Meadow-Provider-None_tests.js
+++ b/test/Meadow-Provider-None_tests.js
@@ -164,7 +164,7 @@ suite
 							function(pError, pQuery, pRecord)
 							{
 								// Can't really test update with NONE
-								
+
 								fDone();
 							}
 						)
@@ -194,7 +194,7 @@ suite
 						testMeadow.doCount(testMeadow.query,
 							function(pError, pQuery, pRecord)
 							{
-								libFable.log.info(pError, pRecord)
+								libFable.log.info(pError, pRecord);
 								Expect(pQuery.parameters.result.executed).to.equal(true);
 								fDone();
 							}

--- a/test/Meadow_tests.js
+++ b/test/Meadow_tests.js
@@ -10,19 +10,7 @@ var Chai = require("chai");
 var Expect = Chai.expect;
 var Assert = Chai.assert;
 
-var libFable = require('fable').new({
-	LogStreams:
-	[
-	    {
-	        level: 'fatal',
-	        streamtype:'process.stdout',
-	    },
-	    {
-	        level: 'trace',
-	        path: __dirname+'/../tests.log'
-	    }
-	]
-});
+var libFable = require('fable');
 
 var _TestAnimalJsonSchema = (
 {
@@ -65,10 +53,25 @@ suite
 	'Meadow',
 	function()
 	{
+		let _Fable;
 		setup
 		(
 			function()
 			{
+				_Fable = libFable.new(
+				{
+					LogStreams:
+					[
+						{
+							level: 'fatal',
+							streamtype:'process.stdout',
+						},
+						{
+							level: 'trace',
+							path: __dirname+'/../tests.log'
+						}
+					]
+				});
 			}
 		);
 
@@ -91,7 +94,7 @@ suite
 					'There should be some basic metadata on the class properties',
 					function()
 					{
-						var testMeadow = require('../source/Meadow.js').new(libFable);
+						var testMeadow = require('../source/Meadow.js').new(_Fable);
 						Expect(testMeadow).to.have.a.property('scope')
 						.that.is.a('string'); // Scope is always a string
 						Expect(testMeadow).to.have.a.property('defaultIdentifier')
@@ -105,7 +108,7 @@ suite
 					'Initialize with values',
 					function()
 					{
-						var testMeadow = require('../source/Meadow.js').new(libFable, 'Animal', _TestAnimalJsonSchema);
+						var testMeadow = require('../source/Meadow.js').new(_Fable, 'Animal', _TestAnimalJsonSchema);
 						Expect(testMeadow.scope)
 							.to.equal('Animal');
 						Expect(testMeadow.jsonSchema.title)
@@ -117,7 +120,7 @@ suite
 					'Try out some role names',
 					function()
 					{
-						var testMeadow = require('../source/Meadow.js').new(libFable, 'Animal', _TestAnimalJsonSchema);
+						var testMeadow = require('../source/Meadow.js').new(_Fable, 'Animal', _TestAnimalJsonSchema);
 						Expect(testMeadow.getRoleName(0))
 							.to.equal('Unauthenticated');
 						Expect(testMeadow.getRoleName(100))
@@ -133,7 +136,7 @@ suite
 					'Alternative initialization',
 					function()
 					{
-						var testMeadow = require('../source/Meadow.js').new(libFable)
+						var testMeadow = require('../source/Meadow.js').new(_Fable)
 							.setScope('Animal')
 							.setSchema(_TestAnimalJsonSchema);
 						Expect(testMeadow.scope)
@@ -148,7 +151,7 @@ suite
 					'Validate a proper animal',
 					function()
 					{
-						var testMeadow = require('../source/Meadow.js').new(libFable, 'Animal', _TestAnimalJsonSchema);
+						var testMeadow = require('../source/Meadow.js').new(_Fable, 'Animal', _TestAnimalJsonSchema);
 						var tmpValidationResults = testMeadow.validateObject({id:10, type:'bunny', name:'foofoo', age:3});
 						Expect(tmpValidationResults.Valid)
 							.to.equal(true);
@@ -159,10 +162,10 @@ suite
 					'Validate a messed up animal',
 					function()
 					{
-						var testMeadow = require('../source/Meadow.js').new(libFable, 'Animal', _TestAnimalJsonSchema);
+						var testMeadow = require('../source/Meadow.js').new(_Fable, 'Animal', _TestAnimalJsonSchema);
 						// Our zombie needs a name!
 						var tmpValidationResults = testMeadow.validateObject({id:9, type:'zombie', age:3});
-						libFable.log.info('Bad Unnamed Zombie Validation Results', tmpValidationResults);
+						_Fable.log.info('Bad Unnamed Zombie Validation Results', tmpValidationResults);
 						Expect(tmpValidationResults.Valid)
 							.to.equal(false);
 					}
@@ -172,7 +175,7 @@ suite
 					'Change provider',
 					function()
 					{
-						var testMeadow = require('../source/Meadow.js').new(libFable, 'Animal', _TestAnimalJsonSchema);
+						var testMeadow = require('../source/Meadow.js').new(_Fable, 'Animal', _TestAnimalJsonSchema);
 						Expect(testMeadow.providerName)
 							.to.equal('None');
 					}
@@ -182,7 +185,7 @@ suite
 					'Test log slow query method',
 					function()
 					{
-						var testMeadow = require('../source/Meadow.js').new(libFable, 'Animal', _TestAnimalJsonSchema);
+						var testMeadow = require('../source/Meadow.js').new(_Fable, 'Animal', _TestAnimalJsonSchema);
 						testMeadow.logSlowQuery(100, testMeadow.query);
 					}
 				);
@@ -191,7 +194,7 @@ suite
 					'Try to change to a bad provider',
 					function()
 					{
-						var testMeadow = require('../source/Meadow.js').new(libFable, 'Animal', _TestAnimalJsonSchema);
+						var testMeadow = require('../source/Meadow.js').new(_Fable, 'Animal', _TestAnimalJsonSchema);
 						Expect(testMeadow.providerName)
 							.to.equal('None');
 						testMeadow.setProvider();
@@ -207,7 +210,7 @@ suite
 					'Try to load from a json package',
 					function()
 					{
-						var testMeadow = require('../source/Meadow.js').new(libFable).loadFromPackage(__dirname+'/Animal.json');
+						var testMeadow = require('../source/Meadow.js').new(_Fable).loadFromPackage(__dirname+'/Animal.json');
 						Expect(testMeadow.scope)
 							.to.equal('FableTest');
 					}
@@ -217,7 +220,7 @@ suite
 					'Try to load from an empty json package',
 					function()
 					{
-						var testMeadow = require('../source/Meadow.js').new(libFable).loadFromPackage(__dirname+'/EmptyPackage.json');
+						var testMeadow = require('../source/Meadow.js').new(_Fable).loadFromPackage(__dirname+'/EmptyPackage.json');
 						Expect(testMeadow.scope)
 							.to.equal('Unknown');
 					}
@@ -227,9 +230,41 @@ suite
 					'Try to load from a bad json package',
 					function()
 					{
-						var testMeadow = require('../source/Meadow.js').new(libFable).loadFromPackage(__dirname+'/BadAnimal.json');
+						var testMeadow = require('../source/Meadow.js').new(_Fable).loadFromPackage(__dirname+'/BadAnimal.json');
 						Expect(testMeadow)
 							.to.equal(false);
+					}
+				);
+
+				test
+				(
+					'Able to override role names',
+					function()
+					{
+						// given
+						_Fable = libFable.new(
+						{
+							MeadowRoleNames: ['Cool', 'Bold', 'Tired'],
+							LogStreams:
+							[
+								{
+									level: 'fatal',
+									streamtype:'process.stdout',
+								},
+								{
+									level: 'trace',
+									path: __dirname+'/../tests.log'
+								}
+							]
+						});
+
+						const meadow = require('../source/Meadow.js').new(_Fable);
+
+						// when
+						const roleNames = [0, 1, 2].map(i => meadow.getRoleName(i));
+
+						// then
+						Expect(roleNames).to.deep.equal(_Fable.settings.MeadowRoleNames);
 					}
 				);
 			}


### PR DESCRIPTION
* Fix duck-typing checks to not fail on Fable 2.x.
* Fill removed Fable `addServices` method to allow usage with Fable 2.x without breaking backward compatibility.
* Require Foxhound version with Fable 2.x fixes.
* Flipped the argument order for a fable error log line.
* Removed recursive call in setProvider which was wigging me out.
* Bring in override mechanism to supplant https://github.com/stevenvelozo/meadow/pull/11/files

Testing done:
* Updated `package.json` to:
  * Point at local foxhound with changes from https://github.com/stevenvelozo/foxhound/pull/16
  * Point at `fable` 2.0.1
* Updated MySQL test harness to use my local MySQL server's username and password.
* Ran coverage tests. They passed.