### PR TITLE
Hotfix for MSSQL Decimal parameters truncating to zero decimal places.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ lib-cov
 
 # Coverage directory used by tools like istanbul
 coverage
+.nyc_output
 
 # Grunt intermediate storage (http://gruntjs.com/creating-plugins#storing-task-files)
 .grunt

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "source/Meadow.js",
   "scripts": {
     "start": "node source/Meadow.js",
-    "coverage": "./node_modules/istanbul/lib/cli.js cover ./node_modules/mocha/bin/_mocha -- -u tdd --exit -R spec",
+    "coverage": "nyc npm run test",
     "test": "./node_modules/mocha/bin/_mocha -u tdd --exit -R spec",
     "tests": "./node_modules/mocha/bin/_mocha -u tdd --exit -R spec --grep",
     "build": "./node_modules/.bin/gulp build --full-paths",

--- a/source/providers/Meadow-Provider-MSSQL.js
+++ b/source/providers/Meadow-Provider-MSSQL.js
@@ -79,6 +79,10 @@ var MeadowProvider = function ()
 				{
 					tmpParameterEntry = _Fable.MeadowMSSQLProvider.MSSQL.VarChar(_Fable.MeadowMSSQLProvider.MSSQL.Max);
 				}
+				else if (tmpParameterType === 'Decimal')
+				{
+					tmpParameterEntry = _Fable.MeadowMSSQLProvider.MSSQL.Decimal(28,10);
+				}
 				else
 				{
 					tmpParameterEntry = _Fable.MeadowMSSQLProvider.MSSQL[tmpParameterType];

--- a/test/Meadow-Provider-MSSQL_tests.js
+++ b/test/Meadow-Provider-MSSQL_tests.js
@@ -63,6 +63,11 @@ var _AnimalJsonSchema = (
 			Type: {
 				description: "The type of the animal",
 				type: "string"
+			},
+			Weight: {
+				description: "The weight of the animal",
+				type: "number",
+				size: "10,3",
 			}
 		},
 		required: ["IDAnimal", "Name", "CreatingIDUser"]
@@ -80,6 +85,7 @@ var _AnimalSchema = (
 		{ Column: "DeleteDate", Type: "DeleteDate" },
 		{ Column: "Name", Type: "String" },
 		{ Column: "Type", Type: "String" },
+		{ Column: "Weight", Type: "Decimal" },
 		{ Column: "Age", Type: "Integer" }
 	]);
 var _AnimalDefault = (
@@ -96,7 +102,8 @@ var _AnimalDefault = (
 		DeletingIDUser: 0,
 
 		Name: 'Unknown',
-		Type: 'Unclassified'
+		Type: 'Unclassified',
+		Weight: 0.0,
 	});
 
 suite
@@ -108,7 +115,7 @@ suite
 
 			var getAnimalInsert = function (pName, pType)
 			{
-				return "INSERT INTO FableTest (GUIDAnimal, CreateDate, CreatingIDUser, UpdateDate, UpdatingIDUser, Deleted, DeleteDate, DeletingIDUser, Name, Type) VALUES ('00000000-0000-0000-0000-000000000000', GETUTCDATE(), 1, GETUTCDATE(), 1, 0, NULL, 0, '" + pName + "', '" + pType + "'); ";
+				return "INSERT INTO FableTest (GUIDAnimal, CreateDate, CreatingIDUser, UpdateDate, UpdatingIDUser, Deleted, DeleteDate, DeletingIDUser, Name, Type, Weight) VALUES ('00000000-0000-0000-0000-000000000000', GETUTCDATE(), 1, GETUTCDATE(), 1, 0, NULL, 0, '" + pName + "', '" + pType + "', 123.456); ";
 			};
 
 			var newMeadow = function ()
@@ -154,7 +161,7 @@ suite
 									},
 									function (fStageComplete)
 									{
-										libFable.MeadowMSSQLProvider.pool.query("CREATE TABLE FableTest (IDAnimal INT IDENTITY(1,1) NOT NULL, GUIDAnimal VARCHAR(36) NOT NULL DEFAULT '00000000-0000-0000-0000-000000000000', CreateDate DATETIME, CreatingIDUser INT NOT NULL DEFAULT '0', UpdateDate DATETIME, UpdatingIDUser INT NOT NULL DEFAULT '0', Deleted TINYINT NOT NULL DEFAULT '0', DeleteDate DATETIME, DeletingIDUser INT NOT NULL DEFAULT '0', Name VARCHAR(128) NOT NULL DEFAULT '', Type VARCHAR(128) NOT NULL DEFAULT '' );").then(()=>{ return fStageComplete(); }).catch(fStageComplete);
+										libFable.MeadowMSSQLProvider.pool.query("CREATE TABLE FableTest (IDAnimal INT IDENTITY(1,1) NOT NULL, GUIDAnimal VARCHAR(36) NOT NULL DEFAULT '00000000-0000-0000-0000-000000000000', CreateDate DATETIME, CreatingIDUser INT NOT NULL DEFAULT '0', UpdateDate DATETIME, UpdatingIDUser INT NOT NULL DEFAULT '0', Deleted TINYINT NOT NULL DEFAULT '0', DeleteDate DATETIME, DeletingIDUser INT NOT NULL DEFAULT '0', Name VARCHAR(128) NOT NULL DEFAULT '', Type VARCHAR(128) NOT NULL DEFAULT '', Weight DECIMAL(10,3) );").then(()=>{ return fStageComplete(); }).catch(fStageComplete);
 									},
 									function (fStageComplete)
 									{
@@ -195,6 +202,7 @@ suite
 			suiteTeardown((fDone) =>
 			{
 				//_SQLConnectionPool.end(fDone);
+				fDone(); // don't hang
 			}
 			);
 
@@ -319,6 +327,8 @@ suite
 												.to.equal('Red Riding Hood');
 											Expect(pRecords[1].Type)
 												.to.equal('Girl');
+											Expect(pRecords[1].Weight)
+												.to.equal(123.456);
 											fDone();
 										}
 									)
@@ -334,7 +344,7 @@ suite
 									testMeadow.fable.settings.QueryThresholdWarnTime = 1;
 
 									var tmpQuery = testMeadow.query
-										.addRecord({ IDAnimal: 2, Type: 'Human' });
+										.addRecord({ IDAnimal: 2, Type: 'Human', Weight: 50.555 });
 
 									testMeadow.doUpdate(tmpQuery,
 										function (pError, pQuery, pQueryRead, pRecord)
@@ -342,6 +352,8 @@ suite
 											// We should have a record ....
 											Expect(pRecord.Type)
 												.to.equal('Human');
+											Expect(pRecord.Weight)
+												.to.equal(50.555);
 
 											testMeadow.fable.settings.QueryThresholdWarnTime = 1000;
 
@@ -572,6 +584,8 @@ suite
 												.to.equal('Red Riding Hood');
 											Expect(pRecords[1].Type)
 												.to.equal('Human');
+											Expect(pRecords[1].Weight)
+												.to.equal(50.555);
 											fDone();
 										}
 									)


### PR DESCRIPTION
This was causing import issues. For now, this just makes the parameter larger than any columns we have, which works, but it would be better to pull this from the schema.

I also fixed coverage which was using the old package which wasn't installed anymore.

Updated tests to have a decimal column, and update it; tests pass now; before, fail with:

```
  143 passing (620ms)
  2 failing

  1) Meadow-Provider-MSSQL
       Query Processing
         Update a record in the database:

      Uncaught AssertionError: expected 51 to equal 50.555
      + expected - actual

      -51
      +50.555

      at /Pavia/meadow/test/Meadow-Provider-MSSQL_tests.js:356:17
      at /Pavia/meadow/source/behaviors/Meadow-Update.js:111:4
      at wrapper (node_modules/async/internal/once.js:12:16)
      at next (node_modules/async/waterfall.js:96:20)
      at /Pavia/meadow/node_modules/async/internal/onlyOnce.js:12:16
      at /Pavia/meadow/source/behaviors/Meadow-Update.js:102:5
      at nextTask (node_modules/async/waterfall.js:90:9)
      at next (node_modules/async/waterfall.js:98:9)
      at /Pavia/meadow/node_modules/async/internal/onlyOnce.js:12:16
      at /Pavia/meadow/source/behaviors/Meadow-Update.js:90:53
      at /Pavia/meadow/source/providers/Meadow-Provider-MSSQL.js:204:17
      at /Pavia/meadow/node_modules/mssql/lib/base/prepared-statement.js:379:14
      at /Pavia/meadow/node_modules/mssql/lib/base/request.js:539:9
      at Request.userCallback (node_modules/mssql/lib/tedious/request.js:841:15)
      at Request.callback (node_modules/tedious/lib/request.js:205:14)
      at Parser.onEndOfMessage (node_modules/tedious/lib/connection.js:2823:22)
      at Object.onceWrapper (node:events:627:28)
      at Parser.emit (node:events:513:28)
      at Readable.<anonymous> (node_modules/tedious/lib/token/token-stream-parser.js:32:12)
      at Readable.emit (node:events:513:28)
      at endReadableNT (node:internal/streams/readable:1358:12)
      at processTicksAndRejections (node:internal/process/task_queues:83:21)

  2) Meadow-Provider-MSSQL
       Logged Query Processing
         Read all records from the database:

      Uncaught AssertionError: expected 51 to equal 50.555
      + expected - actual

      -51
      +50.555

      at /Pavia/meadow/test/Meadow-Provider-MSSQL_tests.js:588:17
      at /Pavia/meadow/source/behaviors/Meadow-Reads.js:64:4
      at wrapper (node_modules/async/internal/once.js:12:16)
      at next (node_modules/async/waterfall.js:96:20)
      at /Pavia/meadow/node_modules/async/internal/onlyOnce.js:12:16
      at /Pavia/meadow/source/behaviors/Meadow-Reads.js:53:7
      at wrapper (node_modules/async/internal/once.js:12:16)
      at replenish (node_modules/async/internal/eachOfLimit.js:76:25)
      at /Pavia/meadow/node_modules/async/internal/eachOfLimit.js:86:9
      at eachLimit (node_modules/async/eachLimit.js:47:43)
      at awaitable (node_modules/async/internal/awaitify.js:13:28)
      at eachSeries (node_modules/async/eachSeries.js:41:34)
      at awaitable (node_modules/async/internal/awaitify.js:13:28)
      at /Pavia/meadow/source/behaviors/Meadow-Reads.js:42:5
      at nextTask (node_modules/async/waterfall.js:90:9)
      at next (node_modules/async/waterfall.js:98:9)
      at /Pavia/meadow/node_modules/async/internal/onlyOnce.js:12:16
      at /Pavia/meadow/source/behaviors/Meadow-Reads.js:28:47
      at /Pavia/meadow/source/providers/Meadow-Provider-MSSQL.js:204:17
      at /Pavia/meadow/node_modules/mssql/lib/base/prepared-statement.js:379:14
      at /Pavia/meadow/node_modules/mssql/lib/base/request.js:539:9
      at Request.userCallback (node_modules/mssql/lib/tedious/request.js:841:15)
      at Request.callback (node_modules/tedious/lib/request.js:205:14)
      at Parser.onEndOfMessage (node_modules/tedious/lib/connection.js:2823:22)
      at Object.onceWrapper (node:events:627:28)
      at Parser.emit (node:events:513:28)
      at Readable.<anonymous> (node_modules/tedious/lib/token/token-stream-parser.js:32:12)
      at Readable.emit (node:events:513:28)
      at endReadableNT (node:internal/streams/readable:1358:12)
      at processTicksAndRejections (node:internal/process/task_queues:83:21)
```